### PR TITLE
Add profiles list to StudentProfileDto

### DIFF
--- a/Tutorz.Application/DTOs/Student/StudentProfileDto.cs
+++ b/Tutorz.Application/DTOs/Student/StudentProfileDto.cs
@@ -26,6 +26,7 @@ namespace Tutorz.Application.DTOs.Student
         public int? ProvinceId { get; set; }
         public int? DistrictId { get; set; }
         public int? CityId { get; set; }
+        public List<Tutorz.Application.DTOs.Auth.StudentProfileDto> Profiles { get; set; } = new();
     }
 
     public class UpdateStudentProfileDto

--- a/Tutorz.Application/Services/AuthService.cs
+++ b/Tutorz.Application/Services/AuthService.cs
@@ -415,6 +415,18 @@ namespace Tutorz.Application.Services
             var user = await _userRepository.GetAsync(u => u.UserId == userId);
             var role = await _roleRepository.GetAsync(r => r.RoleId == user.RoleId);
 
+            // Fetch all profiles for this user
+            var allStudents = await _studentRepository.GetAllAsync(s => s.UserId == user.UserId);
+            var profiles = allStudents.Select(s => new StudentProfileDto
+            {
+                StudentId = s.StudentId,
+                FirstName = s.FirstName,
+                Grade = s.Grade,
+                IsPrimary = s.IsPrimary,
+                ProfileImageUrlSmall = s.ProfileImageUrlSmall,
+                ProfileImageUrlLarge = s.ProfileImageUrlLarge
+            }).ToList();
+
             // Generate Token for THIS specific student
             var token = GenerateJwtToken(user, role.Name, student.StudentId, null);
 
@@ -431,7 +443,7 @@ namespace Tutorz.Application.Services
                 RegistrationNumber = student.RegistrationNumber,
                 ProfileImageUrlSmall = student.ProfileImageUrlSmall,
                 ProfileImageUrlLarge = student.ProfileImageUrlLarge,
-                Profiles = new List<StudentProfileDto>()
+                Profiles = profiles
             };
         }
 

--- a/Tutorz.Application/Services/StudentService.cs
+++ b/Tutorz.Application/Services/StudentService.cs
@@ -108,6 +108,17 @@ namespace Tutorz.Application.Services
                 CityId = student.User?.CityId
             };
 
+            var allStudents = await _studentRepo.GetAllAsync(s => s.UserId == student.UserId);
+            dto.Profiles = allStudents.Select(s => new Tutorz.Application.DTOs.Auth.StudentProfileDto
+            {
+                StudentId = s.StudentId,
+                FirstName = s.FirstName,
+                Grade = s.Grade,
+                IsPrimary = s.IsPrimary,
+                ProfileImageUrlSmall = s.ProfileImageUrlSmall,
+                ProfileImageUrlLarge = s.ProfileImageUrlLarge
+            }).ToList();
+
             if (dto.CityId.HasValue)
             {
                 var city = await _cityRepo.GetAsync(c => c.Id == dto.CityId.Value);


### PR DESCRIPTION
Expose a Profiles collection on the student profile DTO and populate it in related services. StudentProfileDto (Tutorz.Application.DTOs.Student) now includes a List<Tutorz.Application.DTOs.Auth.StudentProfileDto> Profiles property (initialized to an empty list). AuthService and StudentService now fetch all student records for the same user, map them to the Auth.StudentProfileDto shape, and assign that list to the Profiles property when returning student data so consumers can see all profiles associated with the user.